### PR TITLE
Change standard architecture for Xcode 10

### DIFF
--- a/googletest/xcode/gtest.xcodeproj/project.pbxproj
+++ b/googletest/xcode/gtest.xcodeproj/project.pbxproj
@@ -1063,6 +1063,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 40D4CDF10E30E07400294801 /* DebugProject.xcconfig */;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 			};
 			name = Debug;
@@ -1071,6 +1072,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 40D4CDF40E30E07400294801 /* ReleaseProject.xcconfig */;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 			};
 			name = Release;


### PR DESCRIPTION
Fix build error by setting archiectures to "Standard Architectures"
Error: The i386 architecture is deprecated. You should update your ARCHS build setting to remove the i386 architecture.