### PR TITLE
Remove support for i386 in 1.8.0 branch

### DIFF
--- a/googletest/xcode/Config/General.xcconfig
+++ b/googletest/xcode/Config/General.xcconfig
@@ -7,8 +7,8 @@
 //  http://code.google.com/p/google-toolbox-for-mac/
 // 
 
-// Build for PPC and Intel, 32- and 64-bit
-ARCHS = i386 x86_64 ppc ppc64
+// Build for PPC and Intel 64-bit
+ARCHS = x86_64 ppc ppc64
 
 // Zerolink prevents link warnings so turn it off
 ZERO_LINK = NO


### PR DESCRIPTION
This change was made in master google/googltest repo for Xcode 10, not sure what it was about making things dynamic that triggered it being required for CamtasiaTestRunner

Copied from original repo: https://github.com/google/googletest/pull/1855/commits/0272ff1aa0e6a38c2e87b53e92329391d6777145