### PR TITLE
Remove support for i386

### DIFF
--- a/googletest/xcode/Config/General.xcconfig
+++ b/googletest/xcode/Config/General.xcconfig
@@ -7,8 +7,8 @@
 //  http://code.google.com/p/google-toolbox-for-mac/
 // 
 
-// Build for PPC and Intel, 32- and 64-bit
-ARCHS = i386 x86_64 ppc ppc64
+// Build for PPC and Intel 64-bit
+ARCHS = x86_64 ppc ppc64
 
 // Zerolink prevents link warnings so turn it off
 ZERO_LINK = NO


### PR DESCRIPTION
Fixes build error on Mac